### PR TITLE
feat: add ddG/dTm dataset cleaners and data downloading functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,10 @@ If you use TidyMut in your research, please cite:
 
 ```bibtex
 @software{tidymut,
-  title={TidyMut: A Python Package for Biological Sequence Data Processing},
+  title={
+    TidyMut: A comprehensive Python package for processing and analyzing 
+    biological sequence data with advanced mutation analysis capabilities
+  },
   author={YukunR},
   year={2025},
   url={https://github.com/xulab-research/tidymut}

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ pip install -e .
 See [ReadtheDocs](https://tidymut.readthedocs.io/en/latest/user_guide/cleaners.html) for more examples.
 
 ### Supported Datasets
-| Dataset Name    | Reference                                                                           | File                                               | Link                                               |
-| --------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- |
-| cDNAProteolysis | Mega-scale experimental analysis of protein folding stability in biology and design | Tsuboyama2023_Dataset2_Dataset3_20230416.csv       | https://zenodo.org/records/7992926                 |
-| ProteinGym      | ProteinGym: Large-Scale Benchmarks for Protein Design and Fitness Prediction        | DMS_ProteinGym_substitutions.zip                   | https://proteingym.org/download                    |
-| HumanDomainome  | Site-saturation mutagenesis of 500 human protein domains                            | SupplementaryTable2.txt or SupplementaryTable4.txt | https://www.nature.com/articles/s41586-024-08370-4 |
+| Dataset Name    | Reference                                                                           | File                                               | Link                                                                          |
+| --------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------- |
+| cDNAProteolysis | Mega-scale experimental analysis of protein folding stability in biology and design | Tsuboyama2023_Dataset2_Dataset3_20230416.csv       | https://zenodo.org/records/7992926                                            |
+| ProteinGym      | ProteinGym: Large-Scale Benchmarks for Protein Design and Fitness Prediction        | DMS_ProteinGym_substitutions.zip                   | https://proteingym.org/download                                               |
+| HumanDomainome  | Site-saturation mutagenesis of 500 human protein domains                            | SupplementaryTable2.txt or SupplementaryTable4.txt | https://www.nature.com/articles/s41586-024-08370-4                            |
+| ddG             | None                                                                                | M1261.csv, S461.csv, S669.csv, S783.csv, S8754.csv | https://huggingface.co/datasets/xulab-research/TidyMut/tree/main/ddG_datasets |
+| dTm             | None                                                                                | S4346.csv, S557.csv, S571.csv                      | https://huggingface.co/datasets/xulab-research/TidyMut/tree/main/dTm_datasets |
 
 ### Processing cDNAProteolysis Dataset
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "tidymut"
 copyright = "2025, YukunR"
 author = "YukunR"
-release = "v0.3.0"
+release = "v0.4.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/source/user_guide/cleaners.md
+++ b/doc/source/user_guide/cleaners.md
@@ -9,6 +9,7 @@ This guide provides usage examples for data cleaning modules organized by databa
     - [**Supplementary Table 4**](#supplementarytable4-cleaner): Homolog-averaged ∆∆G predictions across families mapped to homologous domains proteome-wide.
 - [**ProteinGym**](#protein-gym-database): ProteinGym: Large-Scale Benchmarks for Protein Design and Fitness Prediction
 - [**cDNAProteolysis**](#cdna-proteolysis-database): Mega-scale experimental analysis of protein folding stability in biology and design
+- [**ddG-dTm Datasets**](#ddg-dtm-datasets): A collection of datasets providing single- and multiple-mutant measurements, labeled by thermodynamic parameters (ΔΔG, ΔTm)
 
 ## Prerequisites
 
@@ -162,3 +163,40 @@ cdnap_cleaning_config.column_mapping = {
 cdnap_cleaning_pipeline = create_cdna_proteolysis_cleaner(dataset_filepath, cdnap_cleaning_config)
 cdnap_cleaning_pipeline, cdnap_dataset = clean_cdna_proteolysis_dataset(cdnap_cleaning_pipeline)
 ```
+
+## ddG-dTm Datasets
+
+### File Preparation
+
+You can download the source file directy by running (see {py:func}`tidymut.utils.download_ddg_dtm_source_file` for details):
+```python
+from tidymut import download_ddg_dtm_source_file
+
+# Download all datasets
+filepaths = download_ddg_dtm_source_file("path/to/target/folder")
+
+# Or specify a particular dataset, e.g.
+filepath = download_ddg_dtm_source_file("path/to/target/folder", sub_dataset = "S571")
+```
+
+### Basic Usage
+
+{py:func}`tidymut.cleaners.ddg_dtm_cleaners.create_ddg_dtm_cleaner` can automatically recognize the label column (ddG or dTm). For example:
+
+```python
+from tidymut.cleaners import (
+    create_ddg_dtm_cleaner,
+    clean_ddg_dtm_dataset
+)
+
+# File settings
+dataset_filepath = "path/to/dataset/file"
+
+# Clean data
+ddgdtm_cleaning_pipeline = create_ddg_dtm_cleaner(dataset_filepath)
+ddgdtm_cleaning_pipeline, ddgdtm_dataset = clean_ddg_dtm_dataset(ddgdtm_cleaning_pipeline)
+```
+
+**Advanced Settings**
+
+See {py:func}`tidymut.cleaners.DdgDtmCleanerConfig` for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.13"
 dependencies = [
     "joblib>=1.5.0",
     "numpy>=2.1.0",
-    "pandas>=2.1.0",
+    "pandas>=2.2.0",
     "tqdm>=4.60.0",
     "python-dateutil>=2.8.2",
     "tzdata>=2022.7",

--- a/tidymut/__init__.py
+++ b/tidymut/__init__.py
@@ -24,6 +24,7 @@ from .core import (
 )
 
 from .cleaners import (
+    basic_cleaners,
     cdna_proteolysis_cleaner,
     human_domainome_sup2_cleaner,
     human_domainome_sup4_cleaner,

--- a/tidymut/__init__.py
+++ b/tidymut/__init__.py
@@ -37,6 +37,7 @@ from .utils import (
     download_cdna_proteolysis_source_file,
     download_protein_gym_source_file,
     download_human_domainome_source_file,
+    download_ddg_dtm_source_file,
     list_datasets_with_built_in_cleaners,
     show_download_instructions,
 )

--- a/tidymut/__init__.py
+++ b/tidymut/__init__.py
@@ -29,6 +29,7 @@ from .cleaners import (
     human_domainome_sup2_cleaner,
     human_domainome_sup4_cleaner,
     protein_gym_cleaner,
+    ddg_dtm_cleaners,
 )
 
 from .utils import (

--- a/tidymut/cleaners/__init__.py
+++ b/tidymut/cleaners/__init__.py
@@ -22,6 +22,12 @@ from .human_domainome_sup4_cleaner import (
     clean_human_domainome_sup4_dataset,
 )
 
+from .ddg_dtm_cleaners import (
+    DdgDtmCleanerConfig,
+    create_ddg_dtm_cleaner,
+    clean_ddg_dtm_dataset,
+)
+
 __all__ = [
     "create_cdna_proteolysis_cleaner",
     "clean_cdna_proteolysis_dataset",
@@ -35,4 +41,7 @@ __all__ = [
     "create_human_domainome_sup4_cleaner",
     "clean_human_domainome_sup4_dataset",
     "HumanDomainomeSup4CleanerConfig",
+    "create_ddg_dtm_cleaner",
+    "clean_ddg_dtm_dataset",
+    "DdgDtmCleanerConfig",
 ]

--- a/tidymut/cleaners/basic_cleaners.py
+++ b/tidymut/cleaners/basic_cleaners.py
@@ -1144,6 +1144,7 @@ def apply_mutations_to_sequences(
     return successful_dataset, failed_dataset
 
 
+@multiout_step(main="success", failed="failed")
 def infer_mutations_from_sequences(
     dataset: pd.DataFrame,
     wt_sequence_column: str = "wt_seq",
@@ -1247,7 +1248,7 @@ def infer_mutations_from_sequences(
     return successful_dataset, failed_dataset
 
 
-@multiout_step(main="successful", failed="failed")
+@multiout_step(main="success", failed="failed")
 def infer_wildtype_sequences(
     dataset: pd.DataFrame,
     name_column: str = "name",

--- a/tidymut/cleaners/basic_cleaners.py
+++ b/tidymut/cleaners/basic_cleaners.py
@@ -49,6 +49,7 @@ __all__ = [
     "apply_mutations_to_sequences",
     "infer_mutations_from_sequences",
     "infer_wildtype_sequences",
+    "average_labels_by_name",
     "convert_to_mutation_dataset_format",
 ]
 
@@ -1429,6 +1430,123 @@ def infer_wildtype_sequences(
     )
 
     return successful_df, failed_df
+
+
+@pipeline_step
+def average_labels_by_name(
+    dataset: pd.DataFrame,
+    name_columns: Union[str, Sequence[str]],
+    label_columns: Union[str, Sequence[str]],
+    remove_origin_columns: bool = True,
+) -> pd.DataFrame:
+    """
+    Average label columns for rows sharing the same name.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe.
+    name_columns : Union[str, Sequence[str]]
+        Column name(s) used for grouping (the "name" keys). Supports
+        a single column or multiple columns for composite keys.
+    label_cols : Union[str, Sequence[str]]
+        Label column(s) to average.
+    remove_origin_columns : bool, default True
+        If True, return one row per name with averaged labels using the
+        ORIGINAL label column names (deduplicated by design).
+        If False, keep original rows and add per-name mean columns named
+        ``<label>_mean_by_name``.
+
+    Returns
+    -------
+    pd.DataFrame
+        - If ``remove_origin_columns`` is True:
+            columns = [name_column] + label_columns (averaged),
+            one row per unique name.
+        - If False:
+            same rows as input plus ``<label>_mean_by_name`` columns.
+
+    Raises
+    ------
+    KeyError
+        If ``name_column`` or any of ``label_columns`` is missing.
+    ValueError
+        If any label column is non-numeric.v
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({
+    ...     "gene": ["A","A","B"],
+    ...     "specie": ["hs","hs","hs"],
+    ...     "y1": [1.0, 3.0, 2.0],
+    ...     "y2": [10.0, 30.0, 20.0]
+    ... })
+    >>> # multiple name keys
+    >>> average_labels_by_name(df, ["gene","specie"], ["y1","y2"], remove_origin_columns=True)
+      gene specie   y1    y2
+    0    A     hs  2.0  20.0
+    1    B     hs  2.0  20.0
+
+    >>> # keep original rows and add means
+    >>> average_labels_by_name(df, "gene", ["y1","y2"], remove_origin_columns=False)
+      gene specie   y1    y2  y1_mean_by_name  y2_mean_by_name
+    0    A     hs  1.0  10.0              2.0             20.0
+    1    A     hs  3.0  30.0              2.0             20.0
+    2    B     hs  2.0  20.0              2.0             20.0
+    """
+    # normalize inputs
+    name_cols = [name_columns] if isinstance(name_columns, str) else list(name_columns)
+    if not name_cols:
+        raise KeyError("name_columns must be a non-empty string or sequence of strings")
+    label_cols = (
+        [label_columns] if isinstance(label_columns, str) else list(label_columns)
+    )
+    if not label_cols:
+        raise KeyError(
+            "label_columns must be a non-empty string or sequence of strings"
+        )
+
+    # existence checks
+    missing_names = [c for c in name_cols if c not in dataset.columns]
+    if missing_names:
+        raise KeyError(f"name_columns not found: {missing_names}")
+    missing_labels = [c for c in label_cols if c not in dataset.columns]
+    if missing_labels:
+        raise KeyError(f"label_columns not found: {missing_labels}")
+
+    # numeric check for labels
+    for c in label_cols:
+        if not pd.api.types.is_numeric_dtype(dataset[c]):
+            raise ValueError(f"label column '{c}' must be numeric")
+
+    # groupby on one or multiple name columns; keep NaN groups as their own group
+    g = dataset.groupby(name_cols, dropna=False)
+    # Compute per-name means (NaNs are ignored by default)
+    if remove_origin_columns:
+        # Return one row per unique name key combination, columns = names + averaged labels
+        means = g[label_cols].mean().reset_index()
+        non_label_cols = [c for c in dataset.columns if c not in set(label_cols)]
+        # Keep original rows and add per-name mean columns named <label>_mean_by_name
+        reps = dataset.drop_duplicates(subset=name_cols, keep="first")[
+            list(dict.fromkeys(name_cols + non_label_cols))
+        ]
+        out = pd.merge(
+            reps,
+            means,
+            on=name_cols,
+            how="left",
+            sort=False,
+            validate="one_to_one",
+        )
+    else:
+        # add <label>_mean_by_name columns to original rows (row count unchanged)
+        means = (
+            g[label_cols]
+            .transform("mean")
+            .rename(columns={c: f"{c}_mean_by_name" for c in label_cols})
+        )
+        out = pd.concat([dataset, means], axis=1)
+    return out
 
 
 @pipeline_step

--- a/tidymut/cleaners/cdna_proteolysis_cleaner.py
+++ b/tidymut/cleaners/cdna_proteolysis_cleaner.py
@@ -14,11 +14,11 @@ from .basic_cleaners import (
     filter_and_clean_data,
     convert_data_types,
     validate_mutations,
+    average_labels_by_name,
     convert_to_mutation_dataset_format,
 )
 from .cdna_proteolysis_custom_cleaners import (
     validate_wt_sequence,
-    average_labels_by_name,
     subtract_labels_by_wt,
 )
 from ..core.dataset import MutationDataset

--- a/tidymut/cleaners/cdna_proteolysis_cleaner.py
+++ b/tidymut/cleaners/cdna_proteolysis_cleaner.py
@@ -168,10 +168,6 @@ def create_cdna_proteolysis_cleaner(
         If config has invalid type
     ValueError
         If configuration validation fails
-
-    Examples
-    --------
-
     """
     # Handle configuration parameter
     if config is None:
@@ -289,17 +285,21 @@ def clean_cdna_proteolysis_dataset(
         - MutationDataset: The cleaned cDNAProteolysis dataset
 
     Examples
+    --------
     >>> pipeline = create_cdna_proteolysis_cleaner(df)  # df is raw cDNAProteolysis dataset file
 
     Use default configuration:
+
     >>> pipeline, dataset = clean_cnda_proteolysis_dataset(pipeline)
 
     Use partial configuration:
+
     >>> pipeline, dataset = clean_cdna_proteolysis_dataset(df, config={
     ...     "validate_mut_workers": 8,
     ... })
 
     Load configuration from file:
+
     >>> pipeline, dataset = clean_cdna_proteolysis_dataset(df, config="config.json")
     """
     try:

--- a/tidymut/cleaners/cdna_proteolysis_cleaner.py
+++ b/tidymut/cleaners/cdna_proteolysis_cleaner.py
@@ -105,7 +105,7 @@ class CDNAProteolysisCleanerConfig(BaseCleanerConfig):
     primary_label_column: str = "label_cDNAProteolysis"
 
     # Override default pipeline name
-    pipeline_name: str = "label_cDNAProteolysis"
+    pipeline_name: str = "cDNAProteolysis"
 
     def validate(self) -> None:
         """Validate cDNAProteolysis-specific configuration parameters

--- a/tidymut/cleaners/cdna_proteolysis_cleaner.py
+++ b/tidymut/cleaners/cdna_proteolysis_cleaner.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
-from typing import Tuple, Dict, Any, Optional, Union, Callable, List
+from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 from pathlib import Path
 import logging
@@ -23,6 +23,9 @@ from .cdna_proteolysis_custom_cleaners import (
 )
 from ..core.dataset import MutationDataset
 from ..core.pipeline import Pipeline, create_pipeline
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 __all__ = [
     "CDNAProteolysisCleanerConfig",

--- a/tidymut/cleaners/cdna_proteolysis_cleaner.py
+++ b/tidymut/cleaners/cdna_proteolysis_cleaner.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
-from typing import Tuple, Dict, Any, Optional, Union, Callable, List, Literal
+from typing import Tuple, Dict, Any, Optional, Union, Callable, List
 from dataclasses import dataclass, field
 from pathlib import Path
 import logging

--- a/tidymut/cleaners/cdna_proteolysis_cleaner.py
+++ b/tidymut/cleaners/cdna_proteolysis_cleaner.py
@@ -147,7 +147,6 @@ def create_cdna_proteolysis_cleaner(
     ----------
     dataset_or_path : Optional[Union[pd.DataFrame, str, Path]], default=None
         Raw dataset DataFrame or file path to cDNAProteolysis dataset.
-        Must be provided if download is False
     config : Optional[Union[CDNAProteolysisCleanerConfig, Dict[str, Any], str, Path]]
         Configuration for the cleaning pipeline. Can be:
         - CDNAProteolysisCleanerConfig object

--- a/tidymut/cleaners/cdna_proteolysis_custom_cleaners.py
+++ b/tidymut/cleaners/cdna_proteolysis_custom_cleaners.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    "average_labels_by_name",
     "validate_wt_sequence",
     "subtract_labels_by_wt",
 ]
@@ -27,124 +26,6 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@pipeline_step
-def average_labels_by_name(
-    dataset: pd.DataFrame,
-    name_columns: Union[str, Sequence[str]],
-    label_columns: Union[str, Sequence[str]],
-    remove_origin_columns: bool = True,
-) -> pd.DataFrame:
-    """
-    Average label columns for rows sharing the same name.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        Input dataframe.
-    name_columns : Union[str, Sequence[str]]
-        Column name(s) used for grouping (the "name" keys). Supports
-        a single column or multiple columns for composite keys.
-    label_cols : Union[str, Sequence[str]]
-        Label column(s) to average.
-    remove_origin_columns : bool, default True
-        If True, return one row per name with averaged labels using the
-        ORIGINAL label column names (deduplicated by design).
-        If False, keep original rows and add per-name mean columns named
-        ``<label>_mean_by_name``.
-
-    Returns
-    -------
-    pd.DataFrame
-        - If ``remove_origin_columns`` is True:
-            columns = [name_column] + label_columns (averaged),
-            one row per unique name.
-        - If False:
-            same rows as input plus ``<label>_mean_by_name`` columns.
-
-    Raises
-    ------
-    KeyError
-        If ``name_column`` or any of ``label_columns`` is missing.
-    ValueError
-        If any label column is non-numeric.v
-
-    Examples
-    --------
-    >>> df = pd.DataFrame({
-    ...     "gene": ["A","A","B"],
-    ...     "specie": ["hs","hs","hs"],
-    ...     "y1": [1.0, 3.0, 2.0],
-    ...     "y2": [10.0, 30.0, 20.0]
-    ... })
-    >>> # multiple name keys
-    >>> average_labels_by_name(df, ["gene","specie"], ["y1","y2"], remove_origin_columns=True)
-      gene specie   y1    y2
-    0    A     hs  2.0  20.0
-    1    B     hs  2.0  20.0
-
-    >>> # keep original rows and add means
-    >>> average_labels_by_name(df, "gene", ["y1","y2"], remove_origin_columns=False)
-      gene specie   y1    y2  y1_mean_by_name  y2_mean_by_name
-    0    A     hs  1.0  10.0              2.0             20.0
-    1    A     hs  3.0  30.0              2.0             20.0
-    2    B     hs  2.0  20.0              2.0             20.0
-    """
-    # normalize inputs
-    name_cols = [name_columns] if isinstance(name_columns, str) else list(name_columns)
-    if not name_cols:
-        raise KeyError("name_columns must be a non-empty string or sequence of strings")
-    label_cols = (
-        [label_columns] if isinstance(label_columns, str) else list(label_columns)
-    )
-    if not label_cols:
-        raise KeyError(
-            "label_columns must be a non-empty string or sequence of strings"
-        )
-
-    # existence checks
-    missing_names = [c for c in name_cols if c not in dataset.columns]
-    if missing_names:
-        raise KeyError(f"name_columns not found: {missing_names}")
-    missing_labels = [c for c in label_cols if c not in dataset.columns]
-    if missing_labels:
-        raise KeyError(f"label_columns not found: {missing_labels}")
-
-    # numeric check for labels
-    for c in label_cols:
-        if not pd.api.types.is_numeric_dtype(dataset[c]):
-            raise ValueError(f"label column '{c}' must be numeric")
-
-    # groupby on one or multiple name columns; keep NaN groups as their own group
-    g = dataset.groupby(name_cols, dropna=False)
-    # Compute per-name means (NaNs are ignored by default)
-    if remove_origin_columns:
-        # Return one row per unique name key combination, columns = names + averaged labels
-        means = g[label_cols].mean().reset_index()
-        non_label_cols = [c for c in dataset.columns if c not in set(label_cols)]
-        # Keep original rows and add per-name mean columns named <label>_mean_by_name
-        reps = dataset.drop_duplicates(subset=name_cols, keep="first")[
-            list(dict.fromkeys(name_cols + non_label_cols))
-        ]
-        out = pd.merge(
-            reps,
-            means,
-            on=name_cols,
-            how="left",
-            sort=False,
-            validate="one_to_one",
-        )
-    else:
-        # add <label>_mean_by_name columns to original rows (row count unchanged)
-        means = (
-            g[label_cols]
-            .transform("mean")
-            .rename(columns={c: f"{c}_mean_by_name" for c in label_cols})
-        )
-        out = pd.concat([dataset, means], axis=1)
-    return out
-
-
-# FIXME: 似乎有点问题，返回值很少
 @multiout_step(main="success", failed="failed")
 def validate_wt_sequence(
     dataset: pd.DataFrame,

--- a/tidymut/cleaners/cdna_proteolysis_custom_cleaners.py
+++ b/tidymut/cleaners/cdna_proteolysis_custom_cleaners.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from typing import TYPE_CHECKING
 
 from ..core.mutation import MutationSet
-from ..core.pipeline import multiout_step, pipeline_step
+from ..core.pipeline import multiout_step
 from ..core.sequence import ProteinSequence
 from ..utils.mutation_converter import invert_mutation_set
 

--- a/tidymut/cleaners/ddg_dtm_cleaners.py
+++ b/tidymut/cleaners/ddg_dtm_cleaners.py
@@ -1,0 +1,347 @@
+# tidymut/cleaners/ddg_dtm_cleaners.py
+from __future__ import annotations
+
+import pandas as pd
+from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from pathlib import Path
+import logging
+
+from .base_config import BaseCleanerConfig
+from .basic_cleaners import (
+    read_dataset,
+    split_columns,
+    merge_columns,
+    extract_and_rename_columns,
+    infer_mutations_from_sequences,
+    convert_data_types,
+    aggregate_labels_by_name,
+    convert_to_mutation_dataset_format,
+)
+
+from ..core.dataset import MutationDataset
+from ..core.pipeline import Pipeline, create_pipeline
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+__all__ = [
+    "DdgDtmCleanerConfig",
+    "create_ddg_dtm_cleaner",
+    "clean_ddg_dtm_dataset",
+]
+
+
+def __dir__() -> List[str]:
+    return __all__
+
+
+# Create module logger
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DdgDtmCleanerConfig(BaseCleanerConfig):
+    """
+    Configuration class for ddG-dTm dataset cleaner.
+    Inherits from BaseCleanerConfig and adds ddG-dTm-specific configuration options.
+
+    Simply run `tidymut.download_ddg_dtm_source_file()` to download the dataset.
+
+    Alternatively, the raw ddG-dTm files can be obtained from:
+
+    - Hugging Face: https://huggingface.co/datasets/xulab-research/TidyMut/tree/main/ddG_datasets
+    - Hugging Face: https://huggingface.co/datasets/xulab-research/TidyMut/tree/main/dTm_datasets
+
+    Attributes
+    ----------
+    column_mapping : Dict[str, str]
+        Mapping from source to target column names
+    type_conversions : Dict[str, str]
+        Data type conversion specifications
+    infer_mut_workers : int
+        Number of workers for mutation inference, set to -1 to use all available CPUs
+    aggregation_strategy : Literal["mean", "first", "nearest"]
+        Aggregate labels by name, see `aggregate_labels_by_name` for details
+    nearest_by : List[Tuple[str, float]]
+        Keep mutation by distance, see `aggregate_labels_by_name` for details
+    label_columns : List[str]
+        List of score columns to process
+    primary_label_column : str
+        Primary score column for the dataset
+    """
+
+    # Column mapping configuration
+    column_mapping: Dict[str, str] = field(
+        default_factory=lambda: {
+            "name": "name",
+            "wt_seq": "wt_seq",
+            "mut_seq": "mut_seq",
+            "pH": "pH",
+            # 'temp' and 'label' cols are added due to dTm or ddG in `create_ddg_dtm_cleaner`
+        }
+    )
+
+    # Type conversion configuration
+    type_conversions: Dict[str, str] = field(default_factory=lambda: {"label": "float"})
+
+    # Mutation inference parameters
+    infer_mut_workers: int = 16
+
+    # Score configuration
+    aggregation_strategy: Literal["mean", "first", "nearest"] = "nearest"
+    nearest_by: List[Tuple[str, float]] = field(default_factory=list)
+
+    # Score columns configuration
+    label_columns: List[str] = field(default_factory=lambda: ["label"])
+    primary_label_column: str = "label"
+
+    # Override default pipeline name
+    pipeline_name: str = "ddG-dTm"
+
+    def __post_init__(self):
+        # If user didn't provide nearest_by, set a sensible default based on column_mapping
+        if self.aggregation_strategy == "nearest" and not self.nearest_by:
+            self.nearest_by = [(self.column_mapping.get("pH", "pH"), 7.0)]
+        # Normalize types: ensure str,float and tuple form
+        self.nearest_by = [(str(col), float(target)) for col, target in self.nearest_by]
+
+    def validate(self) -> None:
+        """Validate ddG-dTm-specific configuration parameters
+
+        Raises
+        ------
+        ValueError
+            If configuration is invalid
+        """
+        # Call parent validation
+        super().validate()
+
+        # Validate score columns
+        if not self.label_columns:
+            raise ValueError("label_columns cannot be empty")
+
+        if self.primary_label_column not in self.label_columns:
+            raise ValueError(
+                f"primary_label_column '{self.primary_label_column}' "
+                f"must be in label_columns {self.label_columns}"
+            )
+
+        # Validate column mapping
+        required_mappings = {"name", "wt_seq", "mut_seq"}
+        missing = required_mappings - set(self.column_mapping.keys())
+        if missing:
+            raise ValueError(f"Missing required column mappings: {missing}")
+
+
+def create_ddg_dtm_cleaner(
+    dataset_or_path: Optional[Union[pd.DataFrame, str, Path]] = None,
+    config: Optional[Union[DdgDtmCleanerConfig, Dict[str, Any], str, Path]] = None,
+) -> Pipeline:
+    """Create ddG-dTm dataset cleaning pipeline
+
+    Parameters
+    ----------
+    dataset_or_path : Optional[Union[pd.DataFrame, str, Path]], default=None
+        Raw dataset DataFrame or file path to ddG-dTm dataset.
+    config : Optional[Union[DdgDtmCleanerConfig, Dict[str, Any], str, Path]]
+        Configuration for the cleaning pipeline. Can be:
+        - DdgDtmCleanerConfig object
+        - Dictionary with configuration parameters (merged with defaults)
+        - Path to JSON configuration file (str or Path)
+        - None (uses default configuration)
+
+    Returns
+    -------
+    Pipeline
+        Pipeline: The cleaning pipeline used
+
+    Raises
+    ------
+    TypeError
+        If config has invalid type
+    ValueError
+        If configuration validation fails
+
+    Notes
+    -----
+    Label columns (dTm or ddG) are automatically detected and added to the pipeline.
+
+    Examples
+    --------
+
+    """
+    # Handle configuration parameter
+    if config is None:
+        final_config = DdgDtmCleanerConfig()
+    elif isinstance(config, DdgDtmCleanerConfig):
+        final_config = config
+    elif isinstance(config, dict):
+        # Partial configuration - merge with defaults
+        default_config = DdgDtmCleanerConfig()
+        final_config = default_config.merge(config)
+    elif isinstance(config, (str, Path)):
+        # Load from file
+        final_config = DdgDtmCleanerConfig.from_json(config)
+    else:
+        raise TypeError(
+            f"config must be DdgDtmCleanerConfig, dict, str, Path or None, "
+            f"got {type(config)}"
+        )
+
+    # Log configuration summary
+    logger.info(
+        f"ddG-dTm dataset will cleaning with pipeline: {final_config.pipeline_name}"
+    )
+    logger.debug(f"Configuration:\n{final_config.get_summary()}")
+
+    def _detect_label_columns(data: pd.DataFrame) -> str:
+        colnames = data.columns
+        if "dTm" in colnames or "ddG" in colnames:
+            label_col = "dTm" if "dTm" in colnames else "ddG"
+            return label_col
+        else:
+            raise ValueError("No dTm or ddG columns found in the dataset")
+
+    try:
+        # Create pipeline
+        pipeline = create_pipeline(dataset_or_path, final_config.pipeline_name)
+
+        # Detect label columns
+        if isinstance(dataset_or_path, (str, Path)):
+            pipeline.then(read_dataset)
+            if pipeline.data is not None:
+                label_col = _detect_label_columns(pipeline.data)
+            else:
+                raise ValueError("No data found in the dataset")
+        elif isinstance(dataset_or_path, pd.DataFrame):
+            label_col = _detect_label_columns(dataset_or_path)
+        else:
+            raise TypeError(
+                f"dataset_or_path must be pd.DataFrame or str/Path, "
+                f"got {type(dataset_or_path)}"
+            )
+        final_config.column_mapping.update({label_col: "label"})
+        if label_col == "ddG":
+            # Add temp configuration for ddG
+            final_config.column_mapping.update({"temp": "temp"})
+            final_config.nearest_by.append(("temp", 25))
+
+        # Add cleaning steps
+        pipeline = (
+            pipeline.delayed_then(
+                extract_and_rename_columns,
+                column_mapping=final_config.column_mapping,
+            )
+            .delayed_then(
+                split_columns,
+                column_to_split=final_config.column_mapping.get("name", "name"),
+                new_column_names=["__rcsb", "__accession", "__chain", "__other"],
+                separator="_",
+                max_splits=3,
+                drop_original=True,
+            )
+            .delayed_then(
+                merge_columns,
+                columns_to_merge=["__rcsb", "__accession", "__chain"],
+                new_column_name=final_config.column_mapping.get("name", "name"),
+                separator="_",
+                drop_original=True,
+            )
+            .delayed_then(
+                infer_mutations_from_sequences,
+                wt_sequence_column=final_config.column_mapping.get("wt_seq", "wt_seq"),
+                mut_sequence_column=final_config.column_mapping.get(
+                    "mut_seq", "mut_seq"
+                ),
+                num_workers=final_config.infer_mut_workers,
+            )
+            .delayed_then(
+                convert_data_types, type_conversions=final_config.type_conversions
+            )
+            .delayed_then(
+                aggregate_labels_by_name,
+                name_columns=[
+                    final_config.column_mapping.get("name", "name"),
+                    "inferred_mutations",
+                ],
+                label_columns=final_config.label_columns,
+                remove_origin_columns=True,
+                strategy=final_config.aggregation_strategy,
+                nearest_by=final_config.nearest_by,
+            )
+            .delayed_then(
+                convert_to_mutation_dataset_format,
+                name_column=final_config.column_mapping.get("name", "name"),
+                mutation_column="inferred_mutations",
+                sequence_column=final_config.column_mapping.get("wt_seq", "wt_seq"),
+                mutated_sequence_column=final_config.column_mapping.get(
+                    "mut_seq", "mut_seq"
+                ),
+                label_column=final_config.primary_label_column,
+                is_zero_based=True,
+            )
+        )
+
+        return pipeline
+
+    except Exception as e:
+        logger.error(f"Error in creating ddG-dTm cleaning pipeline: {str(e)}")
+        raise RuntimeError(f"Error in creating ddG-dTm cleaning pipeline: {str(e)}")
+
+
+def clean_ddg_dtm_dataset(
+    pipeline: Pipeline,
+) -> Tuple[Pipeline, MutationDataset]:
+    """Clean ddG-dTm dataset using configurable pipeline
+
+    Parameters
+    ----------
+    pipeline : Pipeline
+        ddG-dTm dataset cleaning pipeline
+
+    Returns
+    -------
+    Tuple[Pipeline, MutationDataset]
+        - Pipeline: The cleaned pipeline
+        - MutationDataset: The cleaned ddG-dTm dataset
+
+    Examples
+    --------
+    >>> pipeline = create_ddg_dtm_cleaner(df)  # df is raw ddG-dTm dataset file
+
+    Use default configuration:
+
+    >>> pipeline, dataset = clean_ddg_dtm_dataset(pipeline)
+
+    Use partial configuration:
+
+    >>> pipeline, dataset = clean_ddg_dtm_dataset(df, config={
+    ...     "infer_mut_workers": 8,
+    ... })
+
+    Load configuration from file:
+
+    >>> pipeline, dataset = clean_ddg_dtm_dataset(df, config="config.json")
+    """
+    try:
+        # Run pipeline
+        pipeline.execute()
+
+        # Extract results
+        ddg_dtm_dataset_df, ddg_dtm_ref_seq = pipeline.data
+        ddg_dtm_dataset = MutationDataset.from_dataframe(
+            ddg_dtm_dataset_df, ddg_dtm_ref_seq
+        )
+
+        logger.info(
+            f"Successfully cleaned ddG-dTm dataset: "
+            f"{len(ddg_dtm_dataset_df)} mutations from {len(ddg_dtm_ref_seq)} proteins"
+        )
+
+        return pipeline, ddg_dtm_dataset
+    except Exception as e:
+        logger.error(f"Error in running ddG-dTm dataset cleaning pipeline: {str(e)}")
+        raise RuntimeError(
+            f"Error in running ddG-dTm dataset cleaning pipeline: {str(e)}"
+        )

--- a/tidymut/cleaners/human_domainome_sup2_cleaner.py
+++ b/tidymut/cleaners/human_domainome_sup2_cleaner.py
@@ -54,21 +54,18 @@ class HumanDomainomeSup2CleanerConfig(BaseCleanerConfig):
 
     Attributes
     ----------
-    # TODO: modify attributes
-    sequence_dict_path : Union[str, Path]
-        Path to the file containing UniProt ID to sequence mapping
-    header_parser : Callable[[str], Tuple[str, Dict[str, str]]]
-        Parse Header in fasta files and extract relevant information
     column_mapping : Dict[str, str]
         Mapping from source to target column names
+    filters : Dict[str, Callable]
+        Filter conditions for data cleaning
     type_conversions : Dict[str, str]
         Data type conversion specifications
     drop_na_columns: List[str]
         List of column names where null values should be dropped
-    is_zero_based : bool
-        Whether mutation positions are zero-based
-    process_workers : int
-        Number of workers for parallel processing
+    validation_workers : int
+        Number of workers for mutations validation, set to -1 to use all available CPUs
+    infer_wt_workers : int
+        Number of workers for wildtype sequences inference, set to -1 to use all available CPUs
     label_columns : List[str]
         List of score columns to process
     primary_label_column : str

--- a/tidymut/cleaners/human_domainome_sup2_cleaner.py
+++ b/tidymut/cleaners/human_domainome_sup2_cleaner.py
@@ -190,12 +190,14 @@ def create_human_domainome_sup2_cleaner(
     Examples
     --------
     Basic usage:
+
     >>> pipeline = create_human_domainome_sup2_cleaner(
     ...     "human_domainome.csv"
     ... )
     >>> pipeline, dataset = clean_human_domainome_dataset(pipeline)
 
     Custom configuration:
+
     >>> config = {
     ...     "process_workers": 8,
     ...     "type_conversions": {"label_humanDomainome": "float32"}
@@ -206,6 +208,7 @@ def create_human_domainome_sup2_cleaner(
     ... )
 
     Load configuration from file:
+
     >>> pipeline = create_human_domainome_sup2_cleaner(
     ...     "data.csv",
     ...     config="config.json"

--- a/tidymut/cleaners/human_domainome_sup4_cleaner.py
+++ b/tidymut/cleaners/human_domainome_sup4_cleaner.py
@@ -199,25 +199,28 @@ def create_human_domainome_sup4_cleaner(
     Examples
     --------
     Basic usage:
-    >>> pipeline = create_human_domainome_cleaner(
+
+    >>> pipeline = create_human_domainome_sup4_cleaner(
     ...     "human_domainome.csv",
     ...     "uniprot_sequences.fasta"
     ... )
     >>> pipeline, dataset = clean_human_domainome_dataset(pipeline)
 
     Custom configuration:
+
     >>> config = {
     ...     "process_workers": 8,
     ...     "type_conversions": {"label_humanDomainome": "float32"}
     ... }
-    >>> pipeline = create_human_domainome_cleaner(
+    >>> pipeline = create_human_domainome_sup4_cleaner(
     ...     "human_domainome.csv",
     ...     "sequences.csv",
     ...     config=config
     ... )
 
     Load configuration from file:
-    >>> pipeline = create_human_domainome_cleaner(
+
+    >>> pipeline = create_human_domainome_sup4_cleaner(
     ...     "data.csv",
     ...     "sequences.fasta",
     ...     config="config.json"

--- a/tidymut/cleaners/protein_gym_cleaner.py
+++ b/tidymut/cleaners/protein_gym_cleaner.py
@@ -176,14 +176,17 @@ def create_protein_gym_cleaner(
     Examples
     --------
     Process directory of ProteinGym CSV files:
+
     >>> pipeline = create_protein_gym_cleaner("DMS_ProteinGym_substitutions/")
     >>> pipeline, dataset = clean_protein_gym_dataset(pipeline)
 
     Process zip file:
+
     >>> pipeline = create_protein_gym_cleaner("DMS_ProteinGym_substitutions.zip")
     >>> pipeline, dataset = clean_protein_gym_dataset(pipeline)
 
     Custom configuration:
+
     >>> config = {
     ...     "validation_workers": 8,
     ...     "handle_multiple_wt": "first"
@@ -191,6 +194,7 @@ def create_protein_gym_cleaner(
     >>> pipeline = create_protein_gym_cleaner("data/", config=config)
 
     Load configuration from file:
+
     >>> pipeline = create_protein_gym_cleaner("data/", config="config.json")
     """
     # Validate input path

--- a/tidymut/utils/__init__.py
+++ b/tidymut/utils/__init__.py
@@ -10,6 +10,7 @@ from .raw_data_downloader import (
     download_cdna_proteolysis_source_file,
     download_protein_gym_source_file,
     download_human_domainome_source_file,
+    download_ddg_dtm_source_file,
 )
 
 # fmt: off
@@ -20,4 +21,5 @@ __all__ = [
     "download_cdna_proteolysis_source_file", 
     "download_protein_gym_source_file", 
     "download_human_domainome_source_file",
+    "download_ddg_dtm_source_file",
 ]

--- a/tidymut/utils/data_source.py
+++ b/tidymut/utils/data_source.py
@@ -57,6 +57,100 @@ DATASETS = {
             },
         },
     },
+    "ddG_datasets": {
+        "name": "ddG_datasets",
+        "official_url": None,
+        "files": ["M1261.csv", "S461.csv", "S669.csv", "S783.csv", "S8754.csv"],
+        "huggingface_repos": [
+            "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/M1261.csv?download=true",
+            "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S461.csv?download=true",
+            "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S669.csv?download=true",
+            "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S783.csv?download=true",
+            "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S8754.csv?download=true",
+        ],
+        "file_name": [
+            "M1261.csv",
+            "S461.csv",
+            "S669.csv",
+            "S783.csv",
+            "S8754.csv",
+        ],
+        "sub_datasets": {
+            "M1261": {
+                "files": ["M1261.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/M1261.csv?download=true"
+                ],
+                "file_name": ["M1261.csv"],
+            },
+            "S461": {
+                "files": ["S461.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S461.csv?download=true"
+                ],
+                "file_name": ["S461.csv"],
+            },
+            "S669": {
+                "files": ["S669.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S669.csv?download=true"
+                ],
+                "file_name": ["S669.csv"],
+            },
+            "S783": {
+                "files": ["S783.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S783.csv?download=true"
+                ],
+                "file_name": ["S783.csv"],
+            },
+            "S8754": {
+                "files": ["S8754.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/ddG_datasets/S8754.csv?download=true"
+                ],
+                "file_name": ["S8754.csv"],
+            },
+        },
+    },
+    "dTm_datasets": {
+        "name": "dTm_datasets",
+        "official_url": None,
+        "files": ["S4346.csv", "S571.csv", "S557.csv"],
+        "huggingface_repos": [
+            "datasets/xulab-research/TidyMut/resolve/main/dTm_datasets/S4346.csv?download=true",
+            "datasets/xulab-research/TidyMut/resolve/main/dTm_datasets/S571.csv?download=true",
+            "datasets/xulab-research/TidyMut/resolve/main/dTm_datasets/S557.csv?download=true",
+        ],
+        "file_name": [
+            "S4346.csv",
+            "S571.csv",
+            "S557.csv",
+        ],
+        "sub_datasets": {
+            "S4346": {
+                "files": ["S4346.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/dTm_datasets/S4346.csv?download=true"
+                ],
+                "file_name": ["S4346.csv"],
+            },
+            "S571": {
+                "files": ["S571.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/dTm_datasets/S571.csv?download=true"
+                ],
+                "file_name": ["S571.csv"],
+            },
+            "S557": {
+                "files": ["S557.csv"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/dTm_datasets/S557.csv?download=true"
+                ],
+                "file_name": ["S557.csv"],
+            },
+        },
+    },
 }
 
 
@@ -81,6 +175,9 @@ def list_datasets_with_built_in_cleaners() -> None:
     for key, info in DATASETS.items():
         print(f"- {key}: {info['name']}")
         print(f"  - Official URL: {info['official_url']}")
+    print(
+        "\nUse the `show_download_instructions` function to see detailed download instructions."
+    )
 
 
 def show_download_instructions(dataset_key: str) -> None:

--- a/tidymut/utils/data_source.py
+++ b/tidymut/utils/data_source.py
@@ -39,6 +39,23 @@ DATASETS = {
             "SupplementaryTable4.txt",
             "wild_type.fasta",
         ],
+        "sub_datasets": {
+            "Sup2": {
+                "files": ["SupplementaryTable2.txt"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/human_domainome/SupplementaryTable2.txt?download=true"
+                ],
+                "file_name": ["SupplementaryTable2.txt"],
+            },
+            "Sup4": {
+                "files": ["SupplementaryTable4.txt", "wild_type.fasta"],
+                "huggingface_repos": [
+                    "datasets/xulab-research/TidyMut/resolve/main/human_domainome/SupplementaryTable4.txt?download=true",
+                    "datasets/xulab-research/TidyMut/resolve/main/human_domainome/wild_type.fasta?download=true",
+                ],
+                "file_name": ["SupplementaryTable4.txt", "wild_type.fasta"],
+            },
+        },
     },
 }
 
@@ -78,3 +95,9 @@ def show_download_instructions(dataset_key: str) -> None:
     for i, file in enumerate(info["files"]):
         print(f"  - File: {file}")
         print(f"    - Download link: {info['huggingface_repos'][i]}")
+    print(f"\nSub-datasets:")
+    for sub_dataset, sub_info in info.get("sub_datasets", {}).items():
+        print(f"- Sub-dataset: {sub_dataset}")
+        for i, file in enumerate(sub_info["files"]):
+            print(f"  - File: {file}")
+            print(f"    - Download link: {sub_info['huggingface_repos'][i]}")

--- a/tidymut/utils/label_resolvers.py
+++ b/tidymut/utils/label_resolvers.py
@@ -1,0 +1,262 @@
+# label_resolvers.py
+
+r"""
+Label resolvers for aggregating per-group target columns.
+
+This module provides small, composable **resolvers**—callables that, given a
+pandas ``DataFrame`` *group* and a list of *label columns*, return a
+``Series`` of resolved label values. Resolvers are intended to be used inside
+grouped operations (e.g., ``DataFrameGroupBy.apply``) where multiple rows per
+entity must be collapsed to a single, consistent set of labels.
+
+The public entry point :func:`make_resolver` constructs a resolver from a
+strategy name (e.g., ``"mean"``, ``"first"``, ``"nearest"``) or accepts a
+user-supplied callable. The :func:`nearest_resolver_factory` enables
+lexicographic, weighted "nearest row" selection across multiple numeric
+criteria columns.
+
+Notes
+-----
+- **Resolver signature**: ``Resolver = Callable[[pd.DataFrame, list[str]], pd.Series]``.
+  The returned ``Series`` must align with the provided ``label_cols`` order.
+- **Missing values**: For the ``"nearest"`` strategy, missing (NaN) values in
+  criterion columns are treated as ``+inf`` distance so such rows never win.
+- **Column order**: When using mappings (``dict``) for criteria, Python 3.7+
+  preserves insertion order. That order determines lexicographic priority.
+- **Type expectations**:
+  - ``"mean"`` requires numeric label columns; non-numeric values raise
+    ``ValueError``.
+  - ``"nearest"`` requires numeric criterion columns; non-numeric values raise
+    ``ValueError``.
+- **Error handling**: Missing required columns raise ``KeyError``; unknown
+  strategy names raise ``ValueError``.
+
+See Also
+--------
+pandas.DataFrame.groupby : Grouping rows for split-apply-combine workflows.
+numpy.lexsort : Related concept for lexicographic ordering.
+
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Mapping, cast, TYPE_CHECKING
+import pandas as pd
+import numpy as np
+
+if TYPE_CHECKING:
+    from typing import Dict, Sequence, Tuple
+
+__all__ = ["make_resolver"]
+
+
+def __dir__() -> List[str]:
+    return __all__
+
+
+# Public type for resolvers
+Resolver = Callable[[pd.DataFrame, List[str]], pd.Series]
+
+
+def mean_resolver(group: pd.DataFrame, label_cols: List[str]) -> pd.Series:
+    """
+    Compute the numeric mean for each label column within a group.
+
+    Parameters
+    ----------
+    group : pandas.DataFrame
+        A single group of rows (as provided by ``DataFrameGroupBy.apply``).
+    label_cols : list of str
+        Column names whose values will be averaged within the group.
+
+    Returns
+    -------
+    pandas.Series
+        A Series containing the per-label mean values. The index matches
+        ``label_cols`` order.
+
+    Raises
+    ------
+    ValueError
+        If any label column is non-numeric.
+
+    Notes
+    -----
+    - NaN values are ignored by ``DataFrame.mean`` (`numeric_only=True`).
+    - The result is reindexed to preserve the input order of ``label_cols``.
+    """
+    for c in label_cols:
+        if not pd.api.types.is_numeric_dtype(group[c]):
+            raise ValueError(f"label column '{c}' must be numeric for strategy='mean'")
+    s = group[label_cols].mean(numeric_only=True)
+    return s.reindex(label_cols)
+
+
+def first_resolver(group: pd.DataFrame, label_cols: List[str]) -> pd.Series:
+    """
+    Take label values from the first row of the group.
+
+    Parameters
+    ----------
+    group : pandas.DataFrame
+        A single group of rows (as provided by ``DataFrameGroupBy.apply``).
+    label_cols : list of str
+        Column names to extract from the first row.
+
+    Returns
+    -------
+    pandas.Series
+        A Series containing the first-row values for the given labels.
+        The index matches ``label_cols`` order.
+
+    Notes
+    -----
+    - No type checks are performed; values are taken as-is from the first row.
+    """
+    return group.iloc[0][label_cols]
+
+
+def nearest_resolver_factory(
+    criteria: Mapping[str, float] | Sequence[Tuple[str, float]],
+    weights: Mapping[str, float] | Sequence[Tuple[str, float]] | None = None,
+) -> Resolver:
+    """
+    Create a resolver that selects the row minimizing a lexicographic,
+    weighted distance across multiple numeric columns.
+
+    The produced resolver compares rows by building a distance tuple:
+    ``(w1 * |c1 - t1|, w2 * |c2 - t2|, ...)`` for the specified criteria
+    and then picks the row with the smallest tuple (lexicographic order).
+    Missing values (NaN) are treated as ``+inf`` so those rows never win.
+
+    Parameters
+    ----------
+    criteria : mapping[str, float] or sequence of (str, float)
+        Target values for the distance computation. Keys (or first elements
+        of pairs) are column names, values are target scalars. If a mapping
+        is provided, insertion order determines priority (Python 3.7+).
+    weights : mapping[str, float] or sequence of (str, float), optional
+        Optional per-column weights. If omitted, all weights default to 1.0.
+        Must reference the same columns as ``criteria`` if provided.
+
+    Returns
+    -------
+    Resolver
+        A callable of signature ``(group: DataFrame, label_cols: list[str]) -> Series``
+        that returns the label values from the nearest row in the group.
+
+    Raises
+    ------
+    KeyError
+        If a required criterion column is not present in the group.
+    ValueError
+        If a criterion column is non-numeric.
+
+    Examples
+    --------
+    >>> factory = nearest_resolver_factory({"temperature": 25.0, "pH": 7.4})
+    >>> # later inside a groupby-apply:
+    >>> # factory(group_df, ["ddG", "dTm"])
+    """
+    # normalize criteria into ordered list
+    if isinstance(criteria, Mapping):
+        crit_pairs = list(criteria.items())  # preserves insertion order (Py3.7+)
+    else:
+        crit_pairs = list(criteria)
+
+    # normalize weights into dict
+    weight_map: Dict[str, float] = {}
+    if weights is not None:
+        weight_map = (
+            dict(weights.items()) if isinstance(weights, Mapping) else dict(weights)
+        )
+
+    def _resolver(group: pd.DataFrame, label_cols: List[str]) -> pd.Series:
+        # validate columns & numeric types
+        for col, _ in crit_pairs:
+            if col not in group.columns:
+                raise KeyError(f"nearest_by column '{col}' not found in group")
+            if not pd.api.types.is_numeric_dtype(group[col]):
+                raise ValueError(f"nearest_by column '{col}' must be numeric")
+
+        # build a distance tuple for each row
+        def dist_tuple(idx) -> Tuple[float, ...]:
+            row = group.loc[idx]
+            parts: List[float] = []
+            for col, target in crit_pairs:
+                w = float(weight_map.get(col, 1.0))
+                val = row[col]
+                parts.append(
+                    np.inf if pd.isna(val) else abs(float(val) - float(target)) * w
+                )
+            return tuple(parts)
+
+        distances = group.index.to_series().apply(dist_tuple)
+        best_idx = distances.idxmin()
+        return cast(pd.Series, group.loc[best_idx].loc[list(label_cols)])
+
+    return _resolver
+
+
+# --- Registry (string -> resolver) ---
+RESOLVERS: Dict[str, Resolver] = {
+    "mean": mean_resolver,
+    "first": first_resolver,
+    # 'nearest' is created via factory, see make_resolver() below
+}
+
+
+def make_resolver(
+    strategy: str | Resolver,
+    *,
+    nearest_by: Mapping[str, float] | Sequence[Tuple[str, float]] | None = None,
+    nearest_weights: Mapping[str, float] | Sequence[Tuple[str, float]] | None = None,
+) -> Resolver:
+    """
+    Create or return a label resolver from a strategy name or callable.
+
+    Parameters
+    ----------
+    strategy : {"mean", "first", "nearest"} or Callable
+        Strategy identifier or a custom resolver. If a callable is provided,
+        it must have signature ``(group: DataFrame, label_cols: list[str]) -> Series``.
+    nearest_by : mapping[str, float] or sequence of (str, float), optional
+        Criteria for the ``"nearest"`` strategy. Required when
+        ``strategy="nearest"``. See :func:`nearest_resolver_factory`.
+    nearest_weights : mapping[str, float] or sequence of (str, float), optional
+        Weights for the ``"nearest"`` strategy. See :func:`nearest_resolver_factory`.
+
+    Returns
+    -------
+    Resolver
+        A resolver callable that can be passed into higher-level aggregation code.
+
+    Raises
+    ------
+    ValueError
+        If ``strategy`` is unknown or required parameters are missing for
+        the ``"nearest"`` strategy.
+
+    Examples
+    --------
+    >>> res = make_resolver("mean")
+    >>> # or nearest:
+    >>> res = make_resolver("nearest", nearest_by={"temperature": 25.0})
+    >>> # or custom:
+    >>> def pick_row(g, labels):
+    ...     return g.loc[g["score"].idxmax(), labels]
+    >>> res = make_resolver(pick_row)
+    """
+    if callable(strategy):
+        return strategy
+
+    key = str(strategy).lower()
+    if key == "nearest":
+        if nearest_by is None:
+            raise ValueError("strategy='nearest' requires `nearest_by`")
+        return nearest_resolver_factory(nearest_by, nearest_weights)
+
+    if key in RESOLVERS:
+        return RESOLVERS[key]
+
+    raise ValueError(f"Unknown strategy: {strategy!r}")

--- a/tidymut/utils/raw_data_downloader.py
+++ b/tidymut/utils/raw_data_downloader.py
@@ -373,7 +373,6 @@ def download_source_file_from_huggingface(
         target_dataset = target_dataset.get("sub_datasets", {}).get(sub_dataset, {})
     if not target_dataset:
         raise ValueError(f"No dataset found with name: {dataset_name}")
-    print(target_dataset)
     hf_repos = target_dataset.get("huggingface_repos", [])
     if len(hf_repos) == 0:
         raise ValueError(
@@ -464,3 +463,53 @@ def download_human_domainome_source_file(
     return download_source_file_from_huggingface(
         "HumanDomainome", dir, overwrite=overwrite, sub_dataset=sub_dataset
     )
+
+
+def download_ddg_dtm_source_file(
+    dir: str, *, overwrite: bool = False, sub_dataset: Optional[str] = None
+) -> Dict[str, str]:
+    """
+    Download the source file for ddG-dTm datasets from the original source.
+
+    Parameters
+    ----------
+    dir : str
+        The target directory where the file will be saved.
+    overwrite : bool, default=False
+        Whether to overwrite the file if it already exists. Default is False.
+    sub_dataset : Optional[str], default=None
+        Sub-dataset to download. If None, download the entire dataset.
+        Supported options:
+        - ddG datasets: "M1261", "S461", "S669", "S783", "S8754"
+        - dTm datasets: "S4346", "S571", "S557"
+
+    Returns
+    -------
+    Dict[str, str]
+        key: file name,
+        value: file path pointing to the ddG-dTm dataset source file
+    """
+    ddg_datasets = list(DATASETS["ddG_datasets"]["sub_datasets"].keys())
+    dtm_datasets = list(DATASETS["dTm_datasets"]["sub_datasets"].keys())
+    supported_sub_datasets = ddg_datasets + dtm_datasets
+    if sub_dataset is not None and sub_dataset not in supported_sub_datasets:
+        raise ValueError(
+            f"Unsupported sub-dataset. Supported options: "
+            f"{', '.join(supported_sub_datasets)}"
+        )
+
+    if sub_dataset is None:
+        file_paths = download_source_file_from_huggingface(
+            "ddG_datasets", dir, overwrite=overwrite
+        )
+        file_paths.update(
+            download_source_file_from_huggingface(
+                "dTm_datasets", dir, overwrite=overwrite
+            )
+        )
+    else:
+        dataset_name = "ddG_datasets" if sub_dataset in ddg_datasets else "dTm_datasets"
+        file_paths = download_source_file_from_huggingface(
+            dataset_name, dir, overwrite=overwrite, sub_dataset=sub_dataset
+        )
+    return file_paths


### PR DESCRIPTION
### Summary

This PR adds support for ddG/dTm dataset cleaning with new specialized cleaners and dataset downloaders. It includes flexible group-wise label aggregation, exposed basic cleaners at top-level for easier access, and improved documentation with usage examples.

### Features & Enhancements

- **ddG/dTm Dataset Support**
  - Add `ddg_dtm_cleaners` module with specialized cleaners for ddG/dTm datasets.
  - Add `ddG/dTm` dataset downloader and data source integration.
  - Support flexible group-wise label aggregation via `aggregate_labels_by_name`.

- **API Improvements**
  - Expose `basic_cleaners` at top-level `tidymut` for easier access.
  - Add `sub_dataset` parameter to download functions for better dataset organization.

### Docs & DX

- Add ddG-dTm cleaners usage examples with code snippets.
- Update documentation formatting and examples for better clarity.
- Improve docstring accuracy for `HumanDomainomeSup2CleanerConfig`.
- Correct citation information in README.md.

### Bug Fixes & Refactoring

- Remove unused imports and guard typing-only imports with `TYPE_CHECKING`.
- Move `average_labels_by_name` to `basic_cleaners` module for better organization.
- Correct `pipeline_name` in `CDNAProteolysisCleanerConfig`.
- Add missing `@multiout_step` decorators and normalize main output handling.
- Require pandas >= 2.2.0 (was >= 2.1.0) for compatibility.